### PR TITLE
Fix waitforResponse() for AtCommandResponse with empty value 

### DIFF
--- a/zha_functions.h
+++ b/zha_functions.h
@@ -625,8 +625,8 @@ private:
             {
               val[i] = atResponse.getValue()[i];
             }
-            return 1;
           }
+          return 1;
         }
         else
         {


### PR DESCRIPTION
Now `waitforResponse()` also work for command that respond with empty value (like `ST`, `WR` or  `AC` AT commands)